### PR TITLE
Self assigning window.location.hash does nothing on Chrome

### DIFF
--- a/resources/js/Comment.js
+++ b/resources/js/Comment.js
@@ -173,8 +173,9 @@
 				// This looks awfully silly but seems to be needed to have the permalink feature
 				// (at least partially?) working (T295567)
 				if ( window.location.hash !== '' ) {
-					// eslint-disable-next-line no-self-assign
-					window.location.hash = window.location.hash;
+					const hash = window.location.hash;
+					window.location.hash = '';
+					window.location.hash = hash;
 				}
 			} );
 		},


### PR DESCRIPTION
The fix for https://phabricator.wikimedia.org/T295567 does not seem to work on Chrome anymore.
Here is an alternative way to do this.